### PR TITLE
Fixed a logging depreciation warning and writes to the potfiles

### DIFF
--- a/jwtcat.py
+++ b/jwtcat.py
@@ -107,7 +107,7 @@ def main():
         logger.info("JWT: {}".format(token))
         logger.info("Wordlist: {}".format(wordlist.name))
         logger.info("Starting brute-force attacks")
-        logger.warn("Pour yourself some coffee, this might take a while..." )
+        logger.warning("Pour yourself some coffee, this might take a while..." )
 
         start_time = time.time()
 

--- a/jwtcat.py
+++ b/jwtcat.py
@@ -120,7 +120,7 @@ def main():
 
                 # Save the holy secret into a file in case sys.stdout is not responding
                 with open("jwtpot.potfile", "a+") as file:
-                    file.write("{0}:{1}".format(token, word))
+                    file.write("{0}:{1}\n".format(token, word))
                     logger.info("Secret key saved to location: {}".format(file.name))
 
                 break


### PR DESCRIPTION
Changed a call from `logging.warn()` to `logging.warning()` as the former is deprecated.
Added a line break after writing a token-key pair to the potfile so that each pair is on its own line.