### PR TITLE
Fix: Homogenizing the behavior of argparse across different versions of Python3

### DIFF
--- a/jwtcat.py
+++ b/jwtcat.py
@@ -43,9 +43,9 @@ def parse_args():
     )
     subparsers = parser.add_subparsers(
         dest='attack_mode',
-        title="Attack-mode",
-        required=True
+        title="Attack-mode"
     )
+    subparsers.required = True
 
     brute_force_subparser = subparsers.add_parser(
         "brute-force",


### PR DESCRIPTION
Fix code for Issue #12.

ERROR __init__() got an unexpected keyword argument 'required'
was able to reproduce in my environment.
(Ubuntu 18.04 LTS, Python 3.6.9)

In environments where this error occurs with jwtcat, other programs also get the same error when using 'required' as an argument to 'add_subparsers()'.
(Perhaps it's a bug in Python itself?)

The solution is to specify 'required' as an object at another time.