### PR TITLE
bugfix breaking change ignored making the script unusable

### DIFF
--- a/jwtcat.py
+++ b/jwtcat.py
@@ -201,7 +201,7 @@ def run(token, candidate):
         [boolean] -- Result of the decoding attempt
     """
     try:
-        payload = jwt.decode(token, candidate, algorithm=["HS512", "HS256", "H384"])
+        payload = jwt.decode(token, candidate, algorithms=["HS512", "HS256", "H384"])
         return True
 
     except jwt.exceptions.DecodeError:


### PR DESCRIPTION
Currently the signature of the decode method supports any kwarg.

Hence, using kwarg `algorithm` throws a `DecodeError` instead of a `TypeError` because `algorithm` argument is not supported.

Correct argument name is `keywords`.

Reproducer:

```python3
import jwt
secret="top-secret"
token = jwt.encode({"data":"value"}, algorithm="HS512", key=secret)
import jwtcat
jwtcat.run(token, secret) # returns False with the current master, but returns True with the proposed PR
```

